### PR TITLE
provider/sl: don't fail on modify which is a nop

### DIFF
--- a/src/provider/sl/tags.go
+++ b/src/provider/sl/tags.go
@@ -130,9 +130,13 @@ func (img *SLImages) patchTags(patchFn func(orig Tags), force bool, imageIDs ...
 
 		oldNum := len(fields.Tags)
 		patchFn(fields.Tags)
-		// EditImage edits only non-zero-value fields.
-		// Removal of the last tag we need to handle explicitely.
-		if oldNum > 0 && len(fields.Tags) == 0 {
+		if len(fields.Tags) == 0 {
+			if oldNum == 0 {
+				// The patch is a nop, ignore.
+				continue
+			}
+			// EditImage edits only non-zero-value fields.
+			// Removal of the last tag we need to handle explicitely.
 			fields.Description = "{}"
 			fields.Tags = nil
 		}


### PR DESCRIPTION
Fixes an issue, where deleting a tag from an image that has no tags fails with:

```
1 error(s) occurred:

* failed to patch image with id=1234567: Invalid modification structure received.  Expected a skeleton of 'SoftLayer_Virtual_Disk_Image_Citrix_XenServer_Version5'.  You passed string (code="SoftLayer_Exception")
```