### PR TITLE
provider/sl: fixes for copy

### DIFF
--- a/src/provider/sl/copy.go
+++ b/src/provider/sl/copy.go
@@ -80,6 +80,11 @@ func (img *SLImages) datacentersByName(names ...string) ([]*Datacenter, error) {
 }
 
 func (img *SLImages) CopyToDatacenters(id int, datacenters ...string) error {
+	image, err := img.ImageByID(id)
+	if err != nil {
+		return err
+	}
+	datacenters = append(datacenters, image.datacenters()...)
 	d, err := img.datacentersByName(datacenters...)
 	if err != nil {
 		return err

--- a/src/provider/sl/copy.go
+++ b/src/provider/sl/copy.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/fatih/flags"
 )
@@ -84,11 +85,17 @@ func (img *SLImages) CopyToDatacenters(id int, datacenters ...string) error {
 	if err != nil {
 		return err
 	}
+
 	datacenters = append(datacenters, image.datacenters()...)
 	d, err := img.datacentersByName(datacenters...)
 	if err != nil {
 		return err
 	}
+
+	if err := img.WaitReady(id, 2*time.Minute); err != nil {
+		return err
+	}
+
 	req := struct {
 		Parameters []interface{} `json:"parameters"`
 	}{Parameters: []interface{}{d}}

--- a/src/provider/sl/images.go
+++ b/src/provider/sl/images.go
@@ -14,6 +14,11 @@ import (
 	"github.com/shiena/ansicolor"
 )
 
+// Transaction represents an ongoing resource transaction.
+type Transaction struct {
+	ID int `json:"id,omitempty"`
+}
+
 // Datacenter represents a Softlayer datacenter.
 type Datacenter struct {
 	ID       int    `json:"id,omitempty"`

--- a/src/provider/sl/images.go
+++ b/src/provider/sl/images.go
@@ -43,7 +43,7 @@ func (img *Image) globalID() string {
 	return "-"
 }
 
-func (img *Image) datacenters() string {
+func (img *Image) datacenters() []string {
 	var names []string
 	if img.Datacenter != nil {
 		names = append(names, img.Datacenter.Name)
@@ -52,9 +52,9 @@ func (img *Image) datacenters() string {
 		names = append(names, d.Name)
 	}
 	if len(names) == 0 {
-		return "-"
+		return nil
 	}
-	return strings.Join(names, ",")
+	return names
 }
 
 func (img *Image) tags() string {
@@ -131,7 +131,7 @@ func (img Images) Print(mode utils.OutputMode) error {
 				created = image.CreateDate.Format(time.RFC3339)
 			}
 			fmt.Fprintf(w, "[%d] %s\t%d\t%s\t%s\t%s\t%s\n", i, image.Name, image.ID,
-				image.globalID(), created, image.datacenters(), image.tags())
+				image.globalID(), created, strings.Join(image.datacenters(), ","), image.tags())
 		}
 
 		fmt.Fprintln(w)

--- a/src/provider/sl/sl.go
+++ b/src/provider/sl/sl.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	slclient "github.com/maximilien/softlayer-go/client"
 	"github.com/maximilien/softlayer-go/softlayer"
@@ -46,6 +47,139 @@ func New(conf *SLConfig) (*SLImages, error) {
 		account: account,
 		block:   block,
 	}, nil
+}
+
+// Transaction returns an ongoing transaction for the image given by the id.
+//
+// It returns non-nil error when querying the service failed.
+// It return nil Transaction and nil error when there are no ongoing
+// transactions.
+func (img *SLImages) Transaction(id int) (*Transaction, error) {
+	path := fmt.Sprintf("%s/%d/getTransaction.json", img.block.GetName(), id)
+	p, err := img.client.DoRawHttpRequest(path, "GET", empty)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = newError(p); err != nil {
+		return nil, err
+	}
+
+	if bytes.Compare(p, []byte("null")) == 0 {
+		return nil, nil
+	}
+
+	var t Transaction
+	if err = json.Unmarshal(p, &t); err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+// WaitReady waits at most d until all ongoing transactions for image
+// given by the id are finished.
+func (img *SLImages) WaitReady(id int, d time.Duration) error {
+	timeout := time.After(d)
+	parent, err := img.Parent(id)
+	if err != nil {
+		return err
+	}
+
+	if parent != nil && parent.ID != 0 {
+		id = parent.ID
+	}
+
+	children, err := img.Children(id)
+	if err != nil {
+		return err
+	}
+
+	ids := make([]int, len(children))
+	for i, child := range children {
+		ids[i] = child.ID
+	}
+	ids = append(ids, id)
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("waiting for %d to be ready timed out after %s", id, d)
+		default:
+			var ongoing bool
+
+			for _, id := range ids {
+				t, err := img.Transaction(id)
+				if err != nil {
+					return err
+				}
+
+				if t != nil && t.ID != 0 {
+					ongoing = true
+					break
+				}
+			}
+
+			if !ongoing {
+				return nil
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+// Parent returns a parent image for the one given by the id.
+//
+// It returns nil Image and nil error if the image has no parent.
+func (img *SLImages) Parent(id int) (*Image, error) {
+	path := fmt.Sprintf("%s/%d/getParent.json", img.block.GetName(), id)
+	p, err := img.client.DoRawHttpRequest(path, "GET", empty)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = newError(p); err != nil {
+		return nil, err
+	}
+
+	if bytes.Compare(p, []byte("null")) == 0 {
+		return nil, nil
+	}
+
+	var image Image
+	if err = json.Unmarshal(p, &image); err != nil {
+		return nil, err
+	}
+
+	return &image, nil
+
+}
+
+// Children returns children images for the one given by the id.
+//
+// It returns nil Images and nil error if the images has no children.
+func (img *SLImages) Children(id int) (Images, error) {
+	path := fmt.Sprintf("%s/%d/getBlockDevices.json", img.block.GetName(), id)
+	p, err := img.client.DoRawHttpRequest(path, "GET", empty)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = newError(p); err != nil {
+		return nil, err
+	}
+
+	var images Images
+	if err = json.Unmarshal(p, &images); err != nil {
+		return nil, err
+	}
+
+	if len(images) == 0 {
+		return nil, nil
+	}
+
+	return images, nil
 }
 
 // EditImage edits non-zero fields of the image given by the id.


### PR DESCRIPTION
Hey @fatih!

Various fixes for the Softlayer client, improves support for copying the images across datacenters.

Tested manually with all datacenters, funny fact - it does not work with `dal02`, `dal04` and `dal07` as Softlayer claims they're not valid datacenters (:D).

```
$  for d in dal02 dal04 dal07; do  echo "copying to $d"; sleep 2; images copy -id $SOME_ID -to "$d"; done
copying to dal02
You must provide a valid location id. Location id provided: 154770 (code="SoftLayer_Exception_Public")
copying to dal04
You must provide a valid location id. Location id provided: 167092 (code="SoftLayer_Exception_Public")
copying to dal07
You must provide a valid location id. Location id provided: 142776 (code="SoftLayer_Exception_Public")
```

Besides that works pretty good.

Happy New Year!
